### PR TITLE
added a semi-colon (prevent conflicts with bundlers)

### DIFF
--- a/lib/polyfill-resize.js
+++ b/lib/polyfill-resize.js
@@ -91,4 +91,4 @@ if(typeof addEvent!='function'){var addEvent=function(o,t,f,l){var d='addEventLi
 
     head.appendChild(style);
   }
-})()
+})();


### PR DESCRIPTION
without this our minifiers bundlers can produce unexecutable code :
`TypeError: (intermediate value)(...) is not a function`
